### PR TITLE
Adds support for OS X system rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 env:
   - CODECLIMATE_REPO_TOKEN=071b24f5a54c4f4d6b54e2dedd2b162e2a6a1df2ffa1b398baec43546e5735c3
 rvm:
+  - 2.0.0-p481
   - 2.2.3
   - 2.3.0
 script: "bundle exec rspec"

--- a/lib/colored2.rb
+++ b/lib/colored2.rb
@@ -9,7 +9,7 @@ module Colored2
   def self.included(from_class)
     from_class.class_eval do
 
-      def surround_with_color(color: nil, effect: nil, color_self:, string: nil, &block)
+      def surround_with_color(color: nil, effect: nil, color_self: nil, string: nil, &block)
         color_type = if Colored2.background_next? && effect.nil?
                        Colored2.foreground_next!
                        :background

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 require 'rspec/core'
 


### PR DESCRIPTION
Hey there I got a PR replacing the use of colored with colored2 🎉  https://github.com/CocoaPods/Xcodeproj/pull/463

Alas, it failed our CI specifically on our Ruby 2.0 systems. This is a project for iOS developers who would use the bundled version of Ruby, and so we don't want to encourage the use of custom ruby versions. So I've fixed the issue and added the lowest common denominator ([list](https://github.com/CocoaPods/Xcodeproj/blob/master/.travis.yml#L10)) to ensure future awesomeness