### PR TITLE
Add Ruby 2.7 to Travis-CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
 - 2.0.0-p481
 - 2.2.3
 - 2.3.0
+- 2.7.0
 script: bundle exec rspec
 notifications:
   email:


### PR DESCRIPTION
Ruby 2.7 got released some time ago. The first distributions start
shipping it. That's why I think we should add it to test test matrix.