### PR TITLE
Use `+@` for duplicating string literals safely

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -1,6 +1,7 @@
 name: RSpec
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -1,7 +1,6 @@
 name: RSpec
 
 on:
-  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [ '3.4', '3.3', '3.2', '3.1' ]
+        ruby-version: [ '3.4.5', '3.4', '3.3', '3.2', '3.1', '3.0' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [ '3.4.5', '3.4', '3.3', '3.2', '3.1', '3.0' ]
+        ruby-version: [ '3.4.5', '3.4', '3.3', '3.2', '3.1' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/lib/colored2/ascii_decorator.rb
+++ b/lib/colored2/ascii_decorator.rb
@@ -76,7 +76,7 @@ module Colored2
         Colored2::Effect.new(options[:effect])
       ].compact.join
 
-      colored = ''
+      colored = +''
       colored << escape_sequence if options[:beginning] == :on
       colored << string
       if options[:end]


### PR DESCRIPTION
In Ruby 3.4, a warning is issued when a string literal is modified in a file without the frozen_string_literal directive.
This is part of Ruby's ongoing effort to make string literals immutable by default in the future.

Currently, using this library in a Ruby 3.4.2 environment results in warnings when modifying string literals.

```
/home/user/server/vendor/bundle/ruby/3.4.0/gems/colored2-3.1.2/lib/colored2/ascii_decorator.rb:67: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

To address this, this PR proposes using the unary plus operator ( `+@` ) to safely duplicate string literals before mutation.
This change ensures compatibility and avoids warnings across all supported Ruby versions, allowing string literals to be used safely regardless of the Ruby version.